### PR TITLE
Use Hex dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
-        goldrush,
-        {elvis_core, ".*", {git, "https://github.com/inaka/elvis_core.git", {ref, "c5e813e"}}}
+        {goldrush, "0.1.7"},
+        {elvis, "0.2.6-alpha3"}
        ]}.
 
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
   {git,"https://github.com/inaka/aleppo.git",
        {ref,"95e7bc6a2ff0de0cde4d0af353ae86d7dea03095"}},
   1},
- {<<"elvis_core">>,
+ {<<"elvis">>,
   {git,"https://github.com/inaka/elvis_core.git",
        {ref,"c5e813e93260508fd386d91d44f9b434d89097a6"}},
   0},


### PR DESCRIPTION
I'm not sure if this is the correct `elvis` to be using, but it seemed to work. If it looks good to you, this should be enough to get the plugin into Hex.