### PR TITLE
Set column size limit: 80 -> 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ outpup format may be configured separately in the `rebar.config`
        filter => "*.erl",
        rules => [{elvis_style, line_length,
                   #{ignore => [],
-                    limit => 80,
+                    limit => 100,
                     skip_comments => false}},
                  {elvis_style, no_tabs},
                  {elvis_style, no_trailing_whitespace},

--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
     filter => "*.erl",
     rules => [{elvis_style, line_length,
                #{ignore => [],
-                 limit => 80,
+                 limit => 100,
                  skip_comments => false}},
               {elvis_style, no_tabs},
               {elvis_style, no_trailing_whitespace},

--- a/src/rebar3_lint_prv.erl
+++ b/src/rebar3_lint_prv.erl
@@ -92,7 +92,7 @@ default_config() ->
        filter => "*.erl",
        rules => [{elvis_style, line_length,
                   #{ignore => [],
-                    limit => 80,
+                    limit => 100,
                     skip_comments => false}},
                  {elvis_style, no_tabs},
                  {elvis_style, no_trailing_whitespace},


### PR DESCRIPTION
Hi :smile:

At https://github.com/inaka/erlang_guidelines/pull/76 the column size limit is now set to 100.

It may not be relevant to Erlang,  but [Linux recently made a similar rule change](https://lkml.org/lkml/2020/5/29/1038).

Do you plan to change it in rebar3_lint?