### PR TITLE
Prefer explicit config.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - run: rebar3 as xref xref
+      - run: rebar3 xref
       - run: rebar3 dialyzer
       - run: rebar3 escriptize && ./_build/default/bin/rebar3_lint
       - run: rebar3 ct

--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 %% == Dependencies and plugins ==
 
 {deps, [
-    {elvis_core, "~>1.1.1"}
+    {elvis_core, "1.1.1"}
 ]}.
 
 {project_plugins, [rebar3_hex]}.

--- a/rebar.config
+++ b/rebar.config
@@ -22,21 +22,18 @@
     ]}
 ]}.
 
+{xref_checks, [
+    deprecated_function_calls,
+    exports_not_used,
+    locals_not_used
+]}.
+
 %% == Profiles ==
 
 {profiles, [
     {test, [
         {cover_enabled, true},
         {cover_opts, [verbose]}
-    ]},
-    {xref, [
-        {xref_checks, [
-            deprecated_function_calls,
-            exports_not_used,
-            locals_not_used,
-            undefined_function_calls
-        ]},
-        {deps, [{rebar3, {git, "https://github.com/erlang/rebar3.git", {branch, "master"}}}]}
     ]}
 ]}.
 


### PR DESCRIPTION
It seems there's a bug (or an intentional feature that doesn't serve `rebar3_lint`) in the way `rebar3` handles versions with `~>`. I found it [while updating `hackney`](https://github.com/benoitc/hackney/pull/678#issuecomment-799349622) then searched some of the lib.s I pull request too for the same behaviour and this one popped out.
Using `{elvis_core, "~>1.0"}` yields (at the time of this writing) `1.1.1` which is incorrect. I want to avoid this by being explicit, as proposed by `rebar3` up until recently.

---

As can be seen by the fact `rebar.lock` is not updated here, this is still avoidable 😄 