### PR TITLE
Prevent rebar3 crash and more output than required

### DIFF
--- a/src/rebar3_lint_prv.erl
+++ b/src/rebar3_lint_prv.erl
@@ -1,6 +1,6 @@
 -module(rebar3_lint_prv).
 
--export([init/1, do/1, format_error/1]).
+-export([init/1, do/1]).
 -export([default_config/0]).
 
 -define(PROVIDER, lint).
@@ -31,16 +31,12 @@ do(State) ->
             {ok, State};
         {fail, [{throw, Error} | _]} ->
             rebar_api:abort("elvis_core threw an exception: ~p", [Error]);
-        {fail, Reason} ->
-            {error, {"Linting failed with ~p", Reason}}
+        {fail, _} ->
+            {error, "Linting failed"}
     catch
         Error ->
             rebar_api:abort("elvis_core threw an exception: ~p", [Error])
     end.
-
--spec format_error({string(), any()}) -> iolist().
-format_error({Message, Reason}) ->
-    io_lib:format(Message, [Reason]).
 
 -spec get_elvis_config(rebar_state:t()) -> elvis_config:configs().
 get_elvis_config(State) ->

--- a/test/test_app_SUITE.erl
+++ b/test/test_app_SUITE.erl
@@ -19,6 +19,4 @@ test_app(_Config) ->
                         [#{dirs => ["src"],
                            filter => "*.erl",
                            rules => [{elvis_style, max_function_length, #{max_length => 1}}]}]),
-    {error, {Message = "Linting failed with ~p", Reason}} = rebar3_lint_prv:do(BadState),
-    % Check that this doesn't throw
-    io:format("~p", [rebar3_lint_prv:format_error({Message, Reason})]).
+    {error, "Linting failed"} = rebar3_lint_prv:do(BadState).


### PR DESCRIPTION
This was:
1. throwing on `rebar3`'s call to `code:which`, which assumes a return like `{error, {Module, Reason}}`
2. returning the values of the analysis as a term while also printing them to stdout